### PR TITLE
fix/get all transactions

### DIFF
--- a/src/transaction/transaction.interface.ts
+++ b/src/transaction/transaction.interface.ts
@@ -8,8 +8,12 @@ export interface ListQueryOptions {
   endDate?: string;
 }
 
-export interface ListWithPageAndUserOptions extends ListQueryOptions {
+export interface ListServiceOptions extends ListQueryOptions {
   user?: User;
   limit: number;
   offset: number;
+}
+
+export interface ListRepositoryOptions extends ListServiceOptions {
+  nodeEnv: 'production' | undefined;
 }

--- a/src/transaction/transaction.module.ts
+++ b/src/transaction/transaction.module.ts
@@ -4,12 +4,14 @@ import { TransactionRepository } from './transaction.repository';
 import { TransactionController } from './transaction.controller';
 import { TransactionService } from './transaction.service';
 import { AccountsRepository } from '../accounts/accounts.repository';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([TransactionRepository]),
     // * 목록 조회에서 계좌의 소유주를 검증하기 위해 사용합니다.
     TypeOrmModule.forFeature([AccountsRepository]),
+    ConfigModule,
   ],
   controllers: [TransactionController],
   providers: [TransactionService],

--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -6,8 +6,9 @@ import {
 } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
 import { Transaction } from './entities/transaction.entity';
-import { ListWithPageAndUserOptions } from './transaction.interface';
+import { ListServiceOptions } from './transaction.interface';
 import { AccountsRepository } from '../accounts/accounts.repository';
 import { User } from '../users/entities/user.entity';
 import { Connection } from 'typeorm';
@@ -24,11 +25,10 @@ export class TransactionService {
     private readonly accountRepository: AccountsRepository,
     @InjectConnection()
     private connection: Connection,
+    private readonly configService: ConfigService,
   ) {}
 
-  async getAllTransactions(
-    query: ListWithPageAndUserOptions,
-  ): Promise<Transaction[]> {
+  async getAllTransactions(query: ListServiceOptions): Promise<Transaction[]> {
     // * 계좌의 소유주인지 여부를 확인합니다.
     const account = await this.accountRepository.findOne({
       where: { acc_num: query.acc_num },
@@ -47,7 +47,10 @@ export class TransactionService {
         '오직 계좌의 소유주만 해당 계좌의 거래 내역을 조회하실 수 있습니다.',
       );
     }
-    const result = this.transactionRepository.getAllTransactions(query);
+    const result = this.transactionRepository.getAllTransactions({
+      ...query,
+      nodeEnv: this.configService.get('NODE_ENV'),
+    });
     return result;
   }
   async deposit(


### PR DESCRIPTION
## 작업 분류

- [x] 버그 수정
- [] 신규 기능 추가
- [x] 리팩터링
- [ ] 테스트

## 작업 개요
- 거래 내역의 목록을 조회할 때 시간대를 계산하는 과정과 인터페이스를 수정했습니다.

## 상세 내용
- `UTCZeroToday`를 구할 때 `NODE_ENV`을 확인하는 조건문을 추가했습니다.
- 개발 모드일 때는 UTC+0 시간대로 변환을, 헤로쿠로 배포한 환경일 때는 변환을 하지 않도록 했습니다.
- 그 이유는 헤로쿠 서버는 UTC+0 시간대를 적용하기 떄문입니다.
- 레포지토리를 위한 인터페이스를 추가하고, 사용처가 어디인지를 보여주도록 인터페이스의 이름을 수정했습니다.
